### PR TITLE
Implement Cron-Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ this.app.services.CronService.addJob('mySecondJob', {
   })
 ```
 
+## Cluster Mode
+For use in a Cluster Mode for preventing the jobs running on all server. Only one server of the cluster be run a job in a distributively form.
+You only need install the [trailpack-cache](https://github.com/trailsjs/trailpack-cache) and configure a redis server.
+
 ## License
 [MIT](https://github.com/jaumard/trailpack-cron/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -41,17 +41,19 @@ Static jobs can be added on config/cronjs` :
 ```js
 // config/cron.js
 module.exports = {
-  myJob: {
-    schedule: '* * * * * *',
-    onTick: function (app) {
-      app.log.info('I am ticking every second');
-    },
-    onComplete: function (app) {
-      app.log.info('I am done');
-    },
-    start: true, // Start task immediately
-    timezone: 'France/Paris' // Custom timezone
-  }
+  jobs: {
+    myJob: {
+      schedule: '* * * * * *',
+      onTick: function (app) {
+        app.log.info('I am ticking every second');
+      },
+      onComplete: function (app) {
+        app.log.info('I am done');
+      },
+      start: true, // Start task immediately
+      timezone: 'France/Paris' // Custom timezone
+    }
+  }  
 }
 ```
 
@@ -111,9 +113,37 @@ this.app.services.CronService.addJob('mySecondJob', {
   })
 ```
 
-## Cluster Mode
-For use in a Cluster Mode for preventing the jobs running on all server. Only one server of the cluster be run a job in a distributively form.
-You only need install the [trailpack-cache](https://github.com/trailsjs/trailpack-cache) and configure a redis server.
+## Cluster Mode (Redis Support)
+For use in a Cluster Mode for preventing the jobs running on all server.
+Only one server of the cluster be run a job in a distributively form.
+You only need configure a redis server in the cron.js config file.
+
+```js
+// config/cron.js
+module.exports = {
+  cluster: {      
+    host: 'localhost',
+    auth_pass: ''
+    db: 0,
+    ttl: 600 // Default TTL
+  },
+  jobs: {
+    myJob: {
+      schedule: '* * * * * *',
+      onTick: function (app) {
+        app.log.info('I am ticking every second');
+      },
+      onComplete: function (app) {
+        app.log.info('I am done');
+      },
+      start: true, // Start task immediately
+      timezone: 'France/Paris' // Custom timezone
+    }
+  }  
+}
+```
+
+For advanced options for the Redis Client take a look here: [Node Redis Client Options](https://github.com/NodeRedis/node_redis#options-object-properties)
 
 ## License
 [MIT](https://github.com/jaumard/trailpack-cron/blob/master/LICENSE)

--- a/api/services/CronService.js
+++ b/api/services/CronService.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Service = require('trails-service')
-const _ = require('lodash')
 
 /**
  * @module CronService
@@ -10,26 +9,20 @@ const _ = require('lodash')
 module.exports = class CronService extends Service {
 
   init() {
-    /* Detect if Redis Exist */
-    this.clusterServer = false
     let cronJobService = false
-    if (this.app.config.caches && this.app.config.caches.stores){
-      this.clusterServer = _.find(this.app.config.caches.stores, {
-        type: 'redis'
-      })
-    }
-    if (this.clusterServer){
-      const redis = require('redis').createClient(this.clusterServer)
+    const config = this.app.config.cron
+
+    /* Detect if Redis Exist */
+    if (config.cluster){
+      const redis = require('redis').createClient(config.cluster)
       cronJobService = require('cron-cluster')(redis).CronJob
     }
     else {
       cronJobService = require('cron').CronJob
     }
 
-    const config = this.app.config.cron
     const jobs = Object.keys(config.jobs)
     this.jobs = {}
-
     jobs.forEach(job => {
       this.addJob(job, config.jobs[job], cronJobService)
     })

--- a/api/services/CronService.js
+++ b/api/services/CronService.js
@@ -12,18 +12,18 @@ module.exports = class CronService extends Service {
   init() {
     /* Detect if Redis Exist */
     this.clusterServer = false
-    let cronJob = false
-    if(this.app.config.caches && this.app.config.caches.stores){
+    let cronJobService = false
+    if (this.app.config.caches && this.app.config.caches.stores){
       this.clusterServer = _.find(this.app.config.caches.stores, {
         type: 'redis'
       })
     }
-    if(this.clusterServer){
-      const redis = require('redis').createClient(cacheConfig)
-      cronJob = require('cron-cluster')(redis).CronJob
+    if (this.clusterServer){
+      const redis = require('redis').createClient(this.clusterServer)
+      cronJobService = require('cron-cluster')(redis).CronJob
     }
     else {
-      cronJob = require('cron').CronJob
+      cronJobService = require('cron').CronJob
     }
 
     const config = this.app.config.cron
@@ -31,15 +31,15 @@ module.exports = class CronService extends Service {
     this.jobs = {}
 
     jobs.forEach(job => {
-      this.addJob(job, config.jobs[job], cronJob)
+      this.addJob(job, config.jobs[job], cronJobService)
     })
   }
 
-  addJob(name, job, service) {
+  addJob(name, job, CronJobService) {
     if (this.jobs[name]) {
       this.jobs[name].stop()
     }
-    this.jobs[name] = new service(
+    this.jobs[name] = new CronJobService(
       job.schedule,
       () => {
         if (job.onTick) {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "schedule"
   ],
   "dependencies": {
+    "cron": "^1.1.0",
     "cron-cluster": "^1.0.0",
     "ecmas-annotations": "^1.0.2",
-    "lodash": "^4.15.0",
     "trailpack": "^1.0.2",
     "trails-service": "^1.0.0-beta-2"
   },

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "schedule"
   ],
   "dependencies": {
-    "cron": "^1.1.0",
+    "cron-cluster": "^1.0.0",
     "ecmas-annotations": "^1.0.2",
+    "lodash": "^4.15.0",
     "trailpack": "^1.0.2",
     "trails-service": "^1.0.0-beta-2"
   },


### PR DESCRIPTION
Support for Cluster Mode, for not run the same job in all server of the cluster. 
For example if i have a job for resize a image i dont want a run the same task in all server cos is a waste of resources and in some case its impossible running the same job two times on the same time.
This PR use the configuration of the Trailpack-cache for automatically switch to cron-cluster if you have a redis server configured.
Take a look.
Cheers.
